### PR TITLE
docs: import module declare

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,25 @@
 
 koishi-plugin-cron 提供了名为 `ctx.cron()` 的 API，用于分配定时任务。
 
+## 导入类型定义
+
+将 `koishi-plugin-cron` 添加到你的插件依赖中。
+
+`packages.json`:
+
+```json
+"peerDependencies": {
+  "koishi": "^4.15.1",
+  "koishi-plugin-cron": "^2.0.5"
+}
+```
+
+在需要使用 `ctx.cron`（具体用法参下文）的文件顶部添加导入语句：
+
+```ts
+import {} from "koishi-plugin-cron";
+```
+
 ## 基本用法
 
 具体语法可以参考 [GNU Crontab](https://www.gnu.org/software/mcron/manual/html_node/Crontab-file.html)。


### PR DESCRIPTION
Add document parts about importing this module, to prevent build errors.

如果不进行该操作将会导致 `TS2339: Property 'cron' does not exist on type 'Context'.`，但这些步骤并没有出现在文档中。