### PR TITLE
fix: update dependencies and improve cron implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "esbuild": "^0.19.6",
     "esbuild-register": "^3.4.2",
     "jest-mock": "^28.1.3",
-    "koishi": "^4.15.5",
+    "koishi": "^4.18.11",
     "mocha": "^9.2.2",
     "sass": "^1.57.1",
     "shx": "^0.3.4",
@@ -74,9 +74,9 @@
     "yml-register": "^1.1.0"
   },
   "peerDependencies": {
-    "koishi": "^4.15.5"
+    "koishi": "^4.18.11"
   },
   "dependencies": {
-    "cron-parser": "^4.9.0"
+    "cron-parser": "^5.5.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,46 +1,116 @@
-import { Context, Schema } from 'koishi'
-import { CronExpression, parseExpression } from 'cron-parser'
+import { Context, Disposable, Schema } from 'koishi';
+import { CronExpression, CronExpressionParser } from 'cron-parser';
+
+export const name = 'cron';
+export const inject = {
+  implements: ['cron'] as const,
+};
+export const reusable = false
+export const filter = false
+
+export type CronCallback = () => void | Promise<void>;
+
+export type Cron = (this: Context, input: string, callback: CronCallback) => () => void;
 
 declare module 'koishi' {
   interface Context {
-    cron(input: string, callback: () => void): () => void
+    cron(input: string, callback: () => void): () => void;
   }
 }
 
-class Task {
-  public timer: NodeJS.Timeout
+export interface Config { }
 
-  constructor(public ctx: Context, public expr: CronExpression, public callback: () => void) {
-    this.start()
+export const Config: Schema<Config> = Schema.object({});
+
+function formatLogValue(value: unknown) {
+  if (value instanceof Error) {
+    return value.stack ?? value.message;
   }
 
-  start() {
-    this.timer = setTimeout(async () => {
-      this.start()
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function attachServiceOwner<T extends object>(value: T, owner: Context) {
+  if (!Reflect.getOwnPropertyDescriptor(value, Context.current)) {
+    Object.defineProperty(value, Context.current, {
+      value: owner,
+      configurable: true,
+    });
+  }
+
+  return value;
+}
+
+class CronTask {
+  private timer?: Disposable;
+  private disposed = false;
+
+  constructor(
+    private readonly caller: Context,
+    private readonly input: string,
+    private readonly expr: CronExpression,
+    private readonly callback: CronCallback,
+    private readonly logInfo: (...args: unknown[]) => void,
+  ) {
+    this.scheduleNext();
+  }
+
+  private scheduleNext() {
+    if (this.disposed) return;
+
+    const delay = Math.max(this.expr.next().getTime() - Date.now(), 0);
+    this.timer = this.caller.setTimeout(async () => {
+      this.timer = undefined;
+      if (this.disposed) return;
+
+      this.scheduleNext();
       try {
-        await this.callback()
+        await this.callback();
       } catch (error) {
-        this.ctx.logger('cron').warn(error)
+        this.logInfo('计划任务执行失败：', this.input, error);
       }
-    }, this.expr.next().getTime() - Date.now())
+    }, delay);
   }
 
-  stop() {
-    clearTimeout(this.timer)
+  dispose() {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.timer?.();
+    this.timer = undefined;
   }
 }
-
-export const name = 'cron'
-
-export interface Config {}
-
-export const Config: Schema<Config> = Schema.object({})
 
 export function apply(ctx: Context) {
-  ctx.provide('cron')
+  const logger = ctx.logger(name);
 
-  ctx.cron = function cron(this: Context, input: string, callback: () => void) {
-    const task = new Task(this, parseExpression(input), callback)
-    return this.collect('cron', () => task.stop())
+  function logInfo(...args: unknown[]) {
+    logger.info(args.map(formatLogValue).join(' '));
   }
+
+  function cronProxy(this: Context, input: string, callback: CronCallback) {
+    const caller = this ?? ctx;
+
+    const task = new CronTask(
+      caller,
+      input,
+      CronExpressionParser.parse(input),
+      callback,
+      logInfo,
+    );
+
+    return caller.effect(() => () => {
+      task.dispose();
+    });
+  }
+
+  attachServiceOwner(cronProxy, ctx);
+  ctx.set('cron', cronProxy);
 }


### PR DESCRIPTION
本 PR 做了兼容性修复，主要解决插件在当前 Koishi / 依赖环境下的可用性问题。

变更内容：
1. 将 cron-parser 升级到 5.x，并适配新版解析 API。
2. 将原先依赖全局 setTimeout 的调度逻辑改为使用 Koishi 上下文的定时器接口，确保任务生命周期能跟随上下文正确释放。
3. 替换已弃用的 Koishi API，用 ctx.effect() 代替 collect()，避免新的类型告警与未来兼容性风险。
4. 保留原有插件行为与对外用法，避免引入额外配置项或非必要功能变更。
5. 补充并梳理任务释放逻辑，确保 dispose 后不会继续调度后续任务。

---

-> https://forum.koishi.xyz/t/topic/12384/12